### PR TITLE
feat: add FinOps & Governance Champion job description

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Explore specific roles:
 - [Principal Cloud Engineer](./job_descriptions/principal_cloud_engineer.md)
 - [Cloud Architect](./job_descriptions/cloud_architect.md)
 - [Principal Cloud Architect](./job_descriptions/principal_cloud_architect.md)
+- [FinOps & Governance Champion](./job_descriptions/finops_governance_champion.md)
 - [Product QA](./job_descriptions/qa_engineer.md)
 - [QA Champion](./job_descriptions/qa_lead.md)
 - [QA Manager](./job_descriptions/qa_manager.md)

--- a/job_descriptions/finops_governance_champion.md
+++ b/job_descriptions/finops_governance_champion.md
@@ -10,11 +10,12 @@ The FinOps & Governance Champion is responsible for driving financial accountabi
 
 - **Cost Management & Optimization:** Analyze and monitor AWS cloud spending across accounts and services. Identify cost optimization opportunities (right-sizing, Reserved Instances, Savings Plans, spot usage) and drive their implementation. Establish cost allocation strategies using tagging standards and AWS Cost Explorer.
 - **Financial Reporting & Forecasting:** Build and maintain dashboards and reports for cloud cost visibility at team, product, and organizational levels. Provide accurate cost forecasting and budgeting aligned with business planning cycles. Deliver regular cost reviews and showback/chargeback reports to stakeholders.
-- **Governance & Policy Enforcement:** Define and enforce cloud governance policies using AWS Organizations, Service Control Policies (SCPs), and IAM guardrails. Implement preventive and detective controls to ensure compliance with internal standards and regulatory requirements. Manage and maintain Terraform modules and policies (e.g., Sentinel, OPA) to codify governance rules.
+- **Governance & Policy Enforcement:** Define and enforce cloud governance policies using AWS Organizations, Service Control Policies (SCPs), and IAM guardrails. Implement preventive and detective controls to ensure compliance with internal standards and regulatory requirements. Understand and work with Infrastructure as Code (Terraform) and policy-as-code frameworks (OPA) to codify governance rules.
 - **Tagging & Resource Management:** Design and enforce tagging strategies for cost allocation, ownership, and lifecycle management. Identify and remediate untagged, orphaned, or idle resources. Automate resource lifecycle policies to reduce waste.
 - **Collaboration & Enablement:** Partner with engineering and product teams to embed FinOps practices into their workflows. Conduct training sessions and knowledge-sharing workshops on cost-aware architecture and governance. Act as the primary point of contact for cost-related queries and governance exceptions.
 - **Continuous Improvement:** Stay current with AWS pricing models, new services, and FinOps best practices. Contribute to the evolution of governance frameworks and automation. Benchmark cloud spending against industry standards and FinOps Foundation maturity models.
-- **Tooling & Automation:** Implement and manage FinOps tooling (AWS Cost Explorer, AWS Budgets, CUDOS, CID dashboards). Automate cost anomaly detection and alerting. Develop Infrastructure as Code (Terraform) for governance and cost control automation.
+- **Tooling & Automation:** Implement and manage FinOps tooling (AWS Cost Explorer, AWS Budgets, CUDOS, CID dashboards). Automate cost anomaly detection and alerting. Leverage AI-based tools to process cost and usage data, and generate dashboards and insights through natural language interfaces.
+- **KPIs & Business Alignment:** Define, track, and report on cloud financial KPIs aligned with organizational goals. Provide actionable metrics to business roles and leadership to support data-driven decision-making. Deliver executive-level reporting and presentations to management and senior leadership on cloud cost performance, governance posture, and optimization roadmap.
 
 ## What we expect from you
 
@@ -23,14 +24,16 @@ The FinOps & Governance Champion is responsible for driving financial accountabi
 - **Technical Skills:**
     - Solid understanding of AWS services and their pricing models (EC2, S3, RDS, Lambda, ECS, etc.)
     - Experience with AWS cost management tools (Cost Explorer, Budgets, Cost and Usage Reports, Compute Optimizer)
-    - Proficiency in Terraform for Infrastructure as Code, including policy-as-code frameworks (Sentinel, OPA)
+    - Ability to understand and work with Infrastructure as Code (Terraform) and policy-as-code frameworks (OPA)
     - Knowledge of AWS Organizations, Service Control Policies (SCPs), and IAM governance
-    - Experience building dashboards and reports (QuickSight, Grafana, or similar)
+    - Experience building dashboards and reports (QuickSight or similar)
+    - Familiarity with AI tools for data analysis and natural language-driven dashboard generation
     - Proficiency in at least one scripting language (Python, Bash, or similar) for automation
     - Version control with Git
 - **Soft Skills:**
     - Strong analytical skills with the ability to translate financial data into actionable insights
-    - Excellent communication skills to engage both technical and non-technical stakeholders
+    - Excellent communication skills to engage both technical and non-technical stakeholders, including management and senior leadership
+    - Ability to produce executive-level reporting and present cloud financial insights to business and directional areas
     - Proactive mindset with a focus on driving cultural change towards financial accountability
     - Collaborative approach with the ability to influence without direct authority
 
@@ -38,7 +41,7 @@ Preferred Qualifications:
 - FinOps Certified Practitioner or equivalent certification
 - AWS Solutions Architect or Cloud Practitioner certification
 - Experience with chargeback/showback models in multi-team organizations
-- Familiarity with compliance frameworks (SOC 2, ISO 27001, GDPR)
+- Familiarity with AWS CIS Benchmarks and cloud security best practices
 - Experience with observability tools (Dynatrace, CloudWatch) for cost-correlated performance analysis
 - Knowledge of Kubernetes/ECS cost allocation and optimization strategies
 

--- a/job_descriptions/finops_governance_champion.md
+++ b/job_descriptions/finops_governance_champion.md
@@ -16,7 +16,7 @@ The FinOps & Governance Champion is responsible for driving financial accountabi
 - **Continuous Improvement:** Stay current with AWS pricing models, new services, and FinOps best practices. Contribute to the evolution of governance frameworks and automation. Benchmark cloud spending against industry standards and FinOps Foundation maturity models.
 - **Tooling & Automation:** Implement and manage FinOps tooling (AWS Cost Explorer, AWS Budgets, CUDOS, CID dashboards). Automate cost anomaly detection and alerting. Leverage AI-based tools to process cost and usage data, and generate dashboards and insights through natural language interfaces.
 - **KPIs & Business Alignment:** Define, track, and report on cloud financial KPIs aligned with organizational goals. Provide actionable metrics to business roles and leadership to support data-driven decision-making. Deliver executive-level reporting and presentations to management and senior leadership on cloud cost performance, governance posture, and optimization roadmap.
-- **Vendor Management:** Manage the relationship with cloud service providers and third-party vendors, including the issuance of purchase orders, and the review and validation of invoices to ensure accuracy and alignment with contracted terms and budgets.
+- **Vendor Management:** Manage the relationship with cloud service providers and third-party vendors, including the issuance of purchase orders and the review and validation of invoices to ensure accuracy and alignment with contracted terms and budgets.
 
 ## What we expect from you
 
@@ -34,7 +34,7 @@ The FinOps & Governance Champion is responsible for driving financial accountabi
 - **Soft Skills:**
     - Strong analytical skills with the ability to translate financial data into actionable insights
     - Excellent communication skills to engage both technical and non-technical stakeholders, including management and senior leadership
-    - Ability to produce executive-level reporting and present cloud financial insights to business and directional areas
+    - Ability to produce executive-level reporting and present cloud financial insights to business and functional areas
     - Proactive mindset with a focus on driving cultural change towards financial accountability
     - Collaborative approach with the ability to influence without direct authority
 

--- a/job_descriptions/finops_governance_champion.md
+++ b/job_descriptions/finops_governance_champion.md
@@ -16,6 +16,7 @@ The FinOps & Governance Champion is responsible for driving financial accountabi
 - **Continuous Improvement:** Stay current with AWS pricing models, new services, and FinOps best practices. Contribute to the evolution of governance frameworks and automation. Benchmark cloud spending against industry standards and FinOps Foundation maturity models.
 - **Tooling & Automation:** Implement and manage FinOps tooling (AWS Cost Explorer, AWS Budgets, CUDOS, CID dashboards). Automate cost anomaly detection and alerting. Leverage AI-based tools to process cost and usage data, and generate dashboards and insights through natural language interfaces.
 - **KPIs & Business Alignment:** Define, track, and report on cloud financial KPIs aligned with organizational goals. Provide actionable metrics to business roles and leadership to support data-driven decision-making. Deliver executive-level reporting and presentations to management and senior leadership on cloud cost performance, governance posture, and optimization roadmap.
+- **Vendor Management:** Manage the relationship with cloud service providers and third-party vendors, including the issuance of purchase orders, and the review and validation of invoices to ensure accuracy and alignment with contracted terms and budgets.
 
 ## What we expect from you
 
@@ -54,6 +55,6 @@ Preferred Qualifications:
 
 ## With whom
 
-You will be part of the Cloud Enablement Engine or a cross-functional platform team, working alongside Cloud Engineers, Solutions Architects, and DevSecOps professionals. You'll collaborate closely with Product Owners and engineering teams across the organization to establish and maintain cost optimization and governance standards.
+You'll collaborate closely with Product Owners and engineering teams across the organization to establish and maintain cost optimization and governance standards. You will also work hand in hand with the Iberia Tech Finance Manager to align financial practices and requirements, ensuring consistency between cloud cost management and the organization's financial strategy.
 
 Support is available from Software Engineering Teams and Solutions Architects who provide architectural guidance, Cloud Engineers for infrastructure expertise, and Finance stakeholders for budget alignment. Key roles such as Tech Leads and Engineering Managers will help prioritize and champion governance initiatives across their teams. You'll engage with stakeholders at all levels, building a culture of financial accountability and operational excellence.

--- a/job_descriptions/finops_governance_champion.md
+++ b/job_descriptions/finops_governance_champion.md
@@ -1,0 +1,56 @@
+![](../static/iberia.png)
+
+# FinOps & Governance Champion
+
+## Role Description
+
+The FinOps & Governance Champion is responsible for driving financial accountability, cost optimization, and governance best practices across Iberia's cloud infrastructure on AWS. This role ensures that cloud spending is transparent, predictable, and aligned with business objectives while enforcing governance policies that maintain security, compliance, and operational standards. The FinOps & Governance Champion works closely with engineering teams, product owners, and finance stakeholders to embed a cost-aware culture and establish guardrails that enable teams to move fast without compromising on governance. Working primarily with AWS cost management tools, Terraform, and organizational policies, this role bridges the gap between technology, finance, and compliance, fostering a collaborative environment focused on sustainable cloud growth.
+
+## Responsibilities
+
+- **Cost Management & Optimization:** Analyze and monitor AWS cloud spending across accounts and services. Identify cost optimization opportunities (right-sizing, Reserved Instances, Savings Plans, spot usage) and drive their implementation. Establish cost allocation strategies using tagging standards and AWS Cost Explorer.
+- **Financial Reporting & Forecasting:** Build and maintain dashboards and reports for cloud cost visibility at team, product, and organizational levels. Provide accurate cost forecasting and budgeting aligned with business planning cycles. Deliver regular cost reviews and showback/chargeback reports to stakeholders.
+- **Governance & Policy Enforcement:** Define and enforce cloud governance policies using AWS Organizations, Service Control Policies (SCPs), and IAM guardrails. Implement preventive and detective controls to ensure compliance with internal standards and regulatory requirements. Manage and maintain Terraform modules and policies (e.g., Sentinel, OPA) to codify governance rules.
+- **Tagging & Resource Management:** Design and enforce tagging strategies for cost allocation, ownership, and lifecycle management. Identify and remediate untagged, orphaned, or idle resources. Automate resource lifecycle policies to reduce waste.
+- **Collaboration & Enablement:** Partner with engineering and product teams to embed FinOps practices into their workflows. Conduct training sessions and knowledge-sharing workshops on cost-aware architecture and governance. Act as the primary point of contact for cost-related queries and governance exceptions.
+- **Continuous Improvement:** Stay current with AWS pricing models, new services, and FinOps best practices. Contribute to the evolution of governance frameworks and automation. Benchmark cloud spending against industry standards and FinOps Foundation maturity models.
+- **Tooling & Automation:** Implement and manage FinOps tooling (AWS Cost Explorer, AWS Budgets, CUDOS, CID dashboards). Automate cost anomaly detection and alerting. Develop Infrastructure as Code (Terraform) for governance and cost control automation.
+
+## What we expect from you
+
+- **Educational Background:** Bachelor's Degree in Computer Science, Information Technology, Finance, Business Administration, or equivalent practical experience.
+- **Experience:** 3+ years of experience in cloud engineering, cloud financial management, or a related role with strong exposure to AWS cost management and governance.
+- **Technical Skills:**
+    - Solid understanding of AWS services and their pricing models (EC2, S3, RDS, Lambda, ECS, etc.)
+    - Experience with AWS cost management tools (Cost Explorer, Budgets, Cost and Usage Reports, Compute Optimizer)
+    - Proficiency in Terraform for Infrastructure as Code, including policy-as-code frameworks (Sentinel, OPA)
+    - Knowledge of AWS Organizations, Service Control Policies (SCPs), and IAM governance
+    - Experience building dashboards and reports (QuickSight, Grafana, or similar)
+    - Proficiency in at least one scripting language (Python, Bash, or similar) for automation
+    - Version control with Git
+- **Soft Skills:**
+    - Strong analytical skills with the ability to translate financial data into actionable insights
+    - Excellent communication skills to engage both technical and non-technical stakeholders
+    - Proactive mindset with a focus on driving cultural change towards financial accountability
+    - Collaborative approach with the ability to influence without direct authority
+
+Preferred Qualifications:
+- FinOps Certified Practitioner or equivalent certification
+- AWS Solutions Architect or Cloud Practitioner certification
+- Experience with chargeback/showback models in multi-team organizations
+- Familiarity with compliance frameworks (SOC 2, ISO 27001, GDPR)
+- Experience with observability tools (Dynatrace, CloudWatch) for cost-correlated performance analysis
+- Knowledge of Kubernetes/ECS cost allocation and optimization strategies
+
+## How you will work
+
+- **Highly Collaborative Culture:** You'll work closely with developers, product owners, cloud engineers, and finance stakeholders in a collaborative environment focused on transparency, knowledge sharing, and cost-conscious decision-making.
+- **Agile Methodology:** Participate in sprint planning, daily standups, and retrospectives as part of product-oriented teams with high autonomy, embedding FinOps practices into the development lifecycle.
+- **Mentorship & Growth:** Access to Solutions Architects, Tech Leads, and Cloud Engineers for technical guidance. Regular community sessions for sharing FinOps best practices and governance learnings.
+- **Innovation Focus:** Work with modern cloud cost management tooling, policy-as-code frameworks, and automation to continuously improve governance and financial operations.
+
+## With whom
+
+You will be part of the Cloud Enablement Engine or a cross-functional platform team, working alongside Cloud Engineers, Solutions Architects, and DevSecOps professionals. You'll collaborate closely with Product Owners and engineering teams across the organization to establish and maintain cost optimization and governance standards.
+
+Support is available from Software Engineering Teams and Solutions Architects who provide architectural guidance, Cloud Engineers for infrastructure expertise, and Finance stakeholders for budget alignment. Key roles such as Tech Leads and Engineering Managers will help prioritize and champion governance initiatives across their teams. You'll engage with stakeholders at all levels, building a culture of financial accountability and operational excellence.


### PR DESCRIPTION
## Summary

Adds a new job description for the **FinOps & Governance Champion** role under `job_descriptions/` and links it from the main `README.md`.

### What is included

The role definition covers:

- **Cost Management & Optimization** — AWS cloud spend analysis, right-sizing, RI/SP strategy
- **Financial Reporting & Forecasting** — dashboards, showback/chargeback, budget alignment
- **Governance & Policy Enforcement** — SCPs, IAM guardrails, policy-as-code (OPA)
- **Tagging & Resource Management** — tagging standards, orphan/idle resource remediation
- **Collaboration & Enablement** — FinOps culture adoption across engineering teams
- **Tooling & Automation** — Cost Explorer, Budgets, CUDOS/CID dashboards, AI-driven data analysis and natural language dashboard generation
- **KPIs & Business Alignment** — organizational KPIs, executive reporting, and metrics for business roles and leadership
- **Executive Communication** — reporting to management and senior leadership on cost performance and governance posture

### Key decisions

- Only **OPA** as policy-as-code framework (no Sentinel)
- IaC (Terraform) positioned as **understanding and working with**, not deep proficiency
- **AI capabilities** for data processing and natural language-driven dashboards
- **AWS CIS Benchmarks** instead of SOC 2 / ISO 27001 / GDPR
- Strong emphasis on **executive-level communication** and reporting to directional areas

### Structure

Follows the same format as `cloud_engineer.md`:
- Role Description
- Responsibilities
- What we expect from you (education, experience, technical and soft skills, preferred qualifications)
- How you will work
- With whom

### Files changed

- `job_descriptions/finops_governance_champion.md` — new role definition
- `README.md` — added link to the new role in the roles list
